### PR TITLE
chore: Updated Python version specification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     classifiers=[
         "Development Status :: 1 - Planning",
         "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
         "Operating System :: Unix",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: Microsoft :: Windows",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', encoding="utf8") as f:
 
 MAJOR = 0
 MINOR = 13
-PATCH = 4
+PATCH = 5
 
 VERSION = '{}.{}.{}'.format(MAJOR, MINOR, PATCH)
 DESCRIPTION = 'String validation and sanitization'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', encoding="utf8") as f:
 
 MAJOR = 0
 MINOR = 13
-PATCH = 3
+PATCH = 4
 
 VERSION = '{}.{}.{}'.format(MAJOR, MINOR, PATCH)
 DESCRIPTION = 'String validation and sanitization'


### PR DESCRIPTION
The version specification only indicates that Python 3 is required. However, Python 3.7 is still supported, but TypedDict (first introduced in 3.8) is used in a number of the scripts.